### PR TITLE
support townships

### DIFF
--- a/geography/management/commands/bootstrap_geography.py
+++ b/geography/management/commands/bootstrap_geography.py
@@ -740,13 +740,17 @@ class Command(BaseCommand):
 
         tqdm.write('Creating fixtures')
         self.create_nation_fixtures()
-        if not options['counties'] and not options['districts'] and not options['townships']:
+        if (not options['counties'] and not options['districts']
+                and not options['townships']):
             self.create_state_fixtures()
-        if not options['counties'] and not options['states'] and not options['townships']:
+        if (not options['counties'] and not options['states']
+                and not options['townships']):
             self.create_district_fixtures()
-        if not options['states'] and not options['districts'] and not options['townships']:
+        if (not options['states'] and not options['districts']
+                and not options['townships']):
             self.create_county_fixtures()
-        if not options['states'] and not options['counties'] and not options['districts']:
+        if (not options['states'] and not options['counties']
+                and not options['districts']):
             self.create_township_fixtures()
 
         self.stdout.write(


### PR DESCRIPTION
We need to support townships for New England states. AP gives us the data for free, and it's more precise than counties, so we should use it when possible. This gets us divisions and geography for townships. It's still a bit of a work in progress, but it's close.

We won't have this for Maine (which is tomorrow as of writing), but we should have this for the rest of the New England states. The next one is Connecticut on August 14th.