### PR TITLE
Fix district baking for single state

### DIFF
--- a/geography/management/commands/bake/geometries/_district.py
+++ b/geography/management/commands/bake/geometries/_district.py
@@ -9,21 +9,17 @@ from geography.models import Division, Geometry
 
 class DistrictGeometries(object):
     def bake_district_geometries(self):
-        district_geometries = None
+        district_geometries = Geometry.objects.none()
         if self.STATES[0] == "00":
             district_geometries = Geometry.objects.filter(
                 series=self.YEAR, division__level=self.DISTRICT_LEVEL
             )
         else:
             for state in self.STATES:
-                division = Division.objects.get(
+                divisions = Division.objects.filter(
                     level=self.DISTRICT_LEVEL, parent__code=state
                 )
-                if not district_geometries:
-                    district_geometries = division.geometries.filter(
-                        series=self.YEAR
-                    )
-                else:
+                for division in divisions:
                     district_geometries = (
                         district_geometries
                         | division.geometries.filter(series=self.YEAR)


### PR DESCRIPTION
Fix a small bug in the `bake_geography` management command that causes it to fail when the user specifies individual state FIPS codes for states with multiple districts. This bug did not affect baking the entire country by specifying the FIPS code `00` and did not affect baking individual states with a single at-large district. The bug came from using the `get` method, which assumes there will be a unique object returned, rather than using `filter` and iterating over the results.

Note that I also changed the initial assignment of `district_geometries` to an empty queryset rather than `None`. The empty queryset is logically false and you don't seem to be relying on "none-ness" specifically, so that should be fine, and it allows some of the conditional logic to be just a bit cleaner.

As always, thank you so much for making these tools open-source! I'm currently using them to throw together a little personal project and the frameworks that they provide are making it a breeze. I'm so glad you're letting the whole community benefit from your work!